### PR TITLE
Add "test" task as alias of tests (nimble standard command)

### DIFF
--- a/ecs.nimble
+++ b/ecs.nimble
@@ -10,7 +10,12 @@ skipDirs = @["tests"]
 # Dependencies
 requires "variant"
 
-
-task tests, "Run tests":
+template runTests =
     exec "nim c -r tests/common.nim"
     # exec "nim js -r tests/common.nim"
+
+task test, "Run tests":
+    runTests
+
+task tests, "Run tests":
+    runTests


### PR DESCRIPTION
I've ran too many times `nimble test` in this package and get "Success", because no test was ran.

So I made `nimble test` to do the same thing as `nimble tests`.